### PR TITLE
Update numpy version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ joblib==0.11
 matplotlib==2.2.2
 mypy-extensions==0.4.1
 mypy==0.701
-numpy==1.14.2
+numpy
 python-Levenshtein==0.12.0
 python-dateutil==2.7.2
 s3transfer==0.1.13


### PR DESCRIPTION
We don't need a specific version of numpy and issue #15 demonstrates that the unconstrained version installed when creating the conda env doesn't match the version requested in the requirements doc.  This fixes that problem.