### PR TITLE
Adding support for installation via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,32 @@ This release is motivated by a long-term research agenda described [here](https:
 
 ![GIF of Gameplay With Bot](https://craftassist.s3-us-west-2.amazonaws.com/pubr/bot_46.gif)
 
-## Installation & Getting Started
+# Installation
+
+## Option A: Docker
+
+The fastest way to install CraftAssist is by building a [Docker](https://docker.com) image.
+
+Assuming you have Docker installed, clone the repo and run:
+
+```
+cd craftassist/docker
+docker build -t craftassist -f Dockerfile.client .
+```
+
+To start a container, run:
+
+```
+docker run -p 25565:25565 -it --name craftassist-container craftassist
+```
+
+To open an additional shell in that container (needed later), in a separate tab run:
+
+```
+docker exec -it craftassist-container bash
+```
+
+## Option B: Local Setup
 
 Do this section *before* cloning the repo.
 
@@ -72,9 +97,15 @@ To build Cuberite and the C++ Minecraft client:
 make
 ```
 
-### Run the Cuberite instance
+# Interacting with the Agent
 
-Run the following command
+If you did a local install, run the following commands from the cloned repository directory.
+
+If you installed CraftAssist using Docker, run these commands in terminals inside of your Docker container (Docker has been configured to open shells in the correct directory). Also, Docker users should use the `python3` command instead of `python`.
+
+## Run the Cuberite instance
+
+After installation, run:
 
 ```
 python ./python/cuberite_process.py

--- a/README.md
+++ b/README.md
@@ -12,23 +12,12 @@ This release is motivated by a long-term research agenda described [here](https:
 
 The fastest way to install CraftAssist is by building a [Docker](https://docker.com) image.
 
-Assuming you have Docker installed, clone the repo and run:
+After installing Docker, go to your Docker resource settings and make sure that the memory allocated to Docker is at least 4GB 
+(smaller amounts of memory can result in the build crashing). Then, clone the CraftAssist repo and run:
 
 ```
 cd craftassist/docker
 docker build -t craftassist -f Dockerfile.client .
-```
-
-To start a container, run:
-
-```
-docker run -p 25565:25565 -it --name craftassist-container craftassist
-```
-
-To open an additional shell in that container (needed later), in a separate tab run:
-
-```
-docker exec -it craftassist-container bash
 ```
 
 ## Option B: Local Setup
@@ -99,19 +88,24 @@ make
 
 # Interacting with the Agent
 
-If you did a local install, run the following commands from the cloned repository directory.
-
-If you installed CraftAssist using Docker, run these commands in terminals inside of your Docker container (Docker has been configured to open shells in the correct directory). Also, Docker users should use the `python3` command instead of `python`.
-
 ## Run the Cuberite instance
 
-After installation, run:
+If you did a local install, run the following from the cloned repository directory:
 
 ```
 python ./python/cuberite_process.py
 ```
-to start an instance of cuberite instance listening on `localhost:25565`
 
+to start an instance of Cuberite listening on `localhost:25565`
+
+
+If you installed CraftAssist using Docker, start a shell in a new Docker container with:
+
+```
+docker run -p 25565:25565 -it --name craftassist-container craftassist
+```
+
+and run the above `python` command in the default directory of that shell.
 
 ## Connecting your Minecraft game client (so you can see what's happening)
 
@@ -134,8 +128,16 @@ Minecraft has recently release v1.15.2, and our Cuberite system supports at most
 
 ## Running the interactive V0 agent
 
-Assuming you have set up the [Cuberite server](https://github.com/facebookresearch/craftassist#run-the-cuberite-instance)
-and the [client](https://github.com/facebookresearch/craftassist#connecting-your-minecraft-game-client-so-you-can-see-whats-happening), in a separate tab, run:
+Assuming you have set up the [Cuberite server](https://github.com/facebookresearch/craftassist#run-the-cuberite-instance) 
+and the [client](https://github.com/facebookresearch/craftassist#connecting-your-minecraft-game-client-so-you-can-see-whats-happening):
+
+* Docker users should open a second shell in their container with:
+```
+docker exec -it craftassist-container bash
+```
+* Local users should open a new terminal in the repository directory.
+
+In the new shell, run:
 
 ```
 python ./python/craftassist/craftassist_agent.py

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -27,7 +27,7 @@ RUN add-apt-repository ppa:git-core/ppa \
 
 # Clone/make repo
 RUN git lfs clone --recursive https://github.com/facebookresearch/craftassist.git
-WORKDIR craftassist
+WORKDIR /craftassist
 
 RUN curl http://craftassist.s3-us-west-2.amazonaws.com/pubr/models_folder.tar.gz -o models_folder.tar.gz
 RUN tar -xzvf models_folder.tar.gz -C python/craftassist/models/ --strip-components 1

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -1,0 +1,41 @@
+FROM ubuntu:18.04
+
+RUN apt-get -y update
+RUN apt-get install -y \
+        cmake \
+        g++ \
+        git \
+        libboost-all-dev \
+        libeigen3-dev \
+        libgoogle-glog-dev \
+        make \
+        python3-dev \
+        python3-pip \
+        ;
+
+RUN pip3 install torch
+
+
+# Install Git LFS
+COPY gitlfs_install.sh /gitlfs_install.sh
+RUN apt-get install -y software-properties-common  # for add-apt-repository
+RUN add-apt-repository ppa:git-core/ppa \
+        && bash /gitlfs_install.sh \
+        && apt-get install -y git-lfs \
+        && git lfs install
+
+
+# Clone/make repo
+RUN git lfs clone --recursive https://github.com/facebookresearch/craftassist.git
+WORKDIR craftassist
+
+RUN curl http://craftassist.s3-us-west-2.amazonaws.com/pubr/models_folder.tar.gz -o models_folder.tar.gz
+RUN tar -xzvf models_folder.tar.gz -C python/craftassist/models/ --strip-components 1
+RUN make
+
+RUN pip3 install -r requirements.txt
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+CMD ["bash"]

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -35,6 +35,8 @@ RUN make
 
 RUN pip3 install -r requirements.txt
 
+RUN echo "alias python=python3" >> ~/.bashrc
+
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 


### PR DESCRIPTION
Adds a Dockerfile for installing CraftAssist and its dependencies, and updates the README to include instructions for setup using Docker.

Testing building + running the image was done on Mac OS.