### PR TITLE
Adding Material Meta IDs to Segmentation Models

### DIFF
--- a/python/craftassist/craftassist_agent.py
+++ b/python/craftassist/craftassist_agent.py
@@ -74,7 +74,7 @@ class CraftAssistAgent(LocoMCAgent):
         # set up the SubComponentClassifier model
         if self.opts.semseg_model_path:
             self.perception_modules["semseg"] = SubcomponentClassifierWrapper(
-                self, self.opts.semseg_model_path
+                self, self.opts.semseg_model_path, self.opts.semseg_vocab_path
             )
 
         # set up the Geoscorer model
@@ -292,7 +292,10 @@ if __name__ == "__main__":
         help="path to cheat sheet of common commands",
     )
     parser.add_argument(
-        "--semseg_model_path", default="", help="path to semantic segmentation  model"
+        "--semseg_model_path", default="", help="path to semantic segmentation model"
+    )
+    parser.add_argument(
+        "--semseg_vocab_path", default="", help="path to block-id vocab map for segmentation model"
     )
     parser.add_argument("--geoscorer_model_path", default="", help="path to geoscorer model")
     parser.add_argument("--port", type=int, default=25565)

--- a/python/craftassist/voxel_models/make_seg_ds.py
+++ b/python/craftassist/voxel_models/make_seg_ds.py
@@ -1,0 +1,126 @@
+import pickle
+import argparse
+import glob
+import os
+
+import numpy as np
+
+from typing import List, Dict, Set, Tuple
+from pathlib import Path
+from copy import deepcopy
+from tqdm import tqdm
+
+
+def open_house_schematic(house_directory: Path) -> np.ndarray:
+    with open(Path(house_directory) / "schematic.npy", "rb") as file:
+        return np.load(file)
+
+
+def get_unique_pairs(house_dir: Path) -> Set:
+    try:
+        pairs = set()
+        schematic = open_house_schematic(house_dir)
+        
+        # House schematic is in yzx format
+        # (instance schematics are in xyz).
+        for y in range(schematic.shape[0]):
+            for z in range(schematic.shape[1]):
+                for x in range(schematic.shape[2]):
+                    pair = (int(schematic[y, z, x, 0]), int(schematic[y, z, x, 1]))
+                    pairs.add(pair)
+        
+        return pairs
+    except FileNotFoundError:
+        print(f"schematic not found at {house_dir}")
+        return set()
+
+
+
+def make_id_vocabulary(houses_data_path: Path) -> Dict[Tuple[int, int], int]:
+    
+    all_houses = glob.glob(str(houses_data_path / "houses" / "*"))
+
+    all_sets = map(get_unique_pairs, tqdm(all_houses))
+        
+    block_meta_pairs: Set[Tuple[int, int]] = set()
+    for s in all_sets:
+        block_meta_pairs = block_meta_pairs.union(s)
+    
+    vocabulary = {pair: i for i, pair in enumerate(block_meta_pairs)}
+    return vocabulary
+
+
+def make_new_item(house_data_path: Path, item: List, vocabulary) -> List:
+    instance_schematic: np.ndarray = item[0]
+    house_name = item[-1]
+    house_schematic = open_house_schematic(house_data_path / "houses" / house_name)
+
+
+    assert house_schematic.shape[0] == instance_schematic.shape[1]
+    assert house_schematic.shape[1] == instance_schematic.shape[2]
+    assert house_schematic.shape[2] == instance_schematic.shape[0]
+
+    new_schematic = instance_schematic.astype(np.int16)
+
+    for x in range(instance_schematic.shape[0]):
+        for y in range(instance_schematic.shape[1]):
+            for z in range(instance_schematic.shape[2]):
+                pair = (int(house_schematic[y, z, x, 0]), int(house_schematic[y, z, x, 1]))
+                new_schematic[x, y, z] = vocabulary[pair]
+    
+    new_item = list(deepcopy(item))
+    new_item[0] = new_schematic
+    return tuple(new_item)
+
+def create_new_seg_ds(house_data_path: Path, segmentation_data: List, vocabulary: Dict[Tuple[int, int], int]) -> List:
+    new_seg_data = []
+
+    for item in segmentation_data:
+        new_item = make_new_item(house_data_path, item, vocabulary)
+        new_seg_data.append(new_item)
+
+    return new_seg_data
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--house-data-dir", "--house", type=str, required=True)
+    parser.add_argument("--segmentation-data-dir", "--seg", type=str, required=True)
+    parser.add_argument("--out-dir", "--out", type=str, required=True)
+    parser.add_argument("--vocabulary-in", "--vin", type=str, required=False)
+    parser.add_argument("--vocabulary-out", "--vout", type=str, required=False)
+
+    args = parser.parse_args()
+
+    assert args.vocabulary_in is not None or args.vocabulary_out is not None, "Must specify vin or vout"
+
+    house_data_dir = Path(args.house_data_dir)
+    segmentation_data_dir = Path(args.segmentation_data_dir)
+    out_dir = Path(args.out_dir)
+
+    os.makedirs(out_dir, exist_ok=True)
+
+    vocab_in = args.vocabulary_in
+
+    if vocab_in:
+        with open(vocab_in, "rb") as file:
+            vocabulary = pickle.load(file)
+    
+    else:
+        vocabulary = make_id_vocabulary(house_data_dir)
+        with open(args.vocabulary_out, "wb") as file:
+            pickle.dump(vocabulary, file)
+
+    for ds_name in ["training_data.pkl", "validation_data.pkl"]:
+        in_path = segmentation_data_dir / ds_name
+        out_path = out_dir / ds_name
+
+        with open(in_path, "rb") as file:
+            seg_data = pickle.load(file)
+
+        new_ds = create_new_seg_ds(house_data_dir, seg_data, vocabulary)
+
+        with open(out_path, "wb") as file:
+            pickle.dump(new_ds, file)
+
+

--- a/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
+++ b/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 from data_loaders import SemSegData
 import torch
 import torch.nn as nn
-from torch.util.data import DataLoader
+from torch.utils.data import DataLoader
 import torch.optim as optim
 
 import semseg_models as models

--- a/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
+++ b/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
@@ -150,7 +150,12 @@ if __name__ == "__main__":
     data_dir = Path(args.data_dir)
 
     train_data = SemSegData(data_dir / "training_data.pkl", nexamples=args.debug, augment=aug)
-    valid_data = SemSegData(data_dir / "validation_data.pkl")
+    print("loaded train")
+    valid_data = SemSegData(
+        data_dir / "validation_data.pkl", 
+        classes_to_match=train_data.classes, 
+        )
+    print("loaded valid")
 
     shuffle = True
     if args.debug > 0:

--- a/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
+++ b/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
@@ -149,6 +149,9 @@ if __name__ == "__main__":
     parser.add_argument("--ndonkeys", type=int, default=4, help="workers in dataloader")
     args = parser.parse_args()
 
+    if args.save_model == "":
+        print("WARNING: No save path specified, model will not be saved.")
+
     this_dir = os.path.dirname(os.path.realpath(__file__))
     parent_dir = os.path.join(this_dir, "../")
     sys.path.append(parent_dir)

--- a/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
+++ b/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
@@ -109,6 +109,9 @@ if __name__ == "__main__":
         default=0.01,
         help="prob of taking gradients on empty locations",
     )
+
+    parser.add_argument("--num_words", default=1024, type=int, help="number of rows in embedding table")
+
     parser.add_argument("--ndonkeys", type=int, default=4, help="workers in dataloader")
     args = parser.parse_args()
 
@@ -141,7 +144,6 @@ if __name__ == "__main__":
     )
 
     args.num_classes = len(train_data.classes["idx2name"])
-    args.num_words = 256
     print("making model")
     args.load = False
     if args.load_model != "":

--- a/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
+++ b/python/craftassist/voxel_models/semantic_segmentation/train_semantic_segmentation.py
@@ -5,6 +5,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import os
 import argparse
 import sys
+from tqdm import tqdm
 from data_loaders import SemSegData
 import torch
 import torch.nn as nn
@@ -57,7 +58,7 @@ def validate(model, validation_data):
 def train_epoch(model, DL, loss, optimizer, args):
     model.train()
     losses = []
-    for b in DL:
+    for b in tqdm(DL):
         x = b[0]
         y = b[1]
         if args.cuda:
@@ -158,7 +159,7 @@ if __name__ == "__main__":
     optimizer = optim.Adagrad(model.parameters(), lr=args.lr)
 
     print("training")
-    for m in range(args.num_epochs):
+    for m in tqdm(range(args.num_epochs)):
         losses = train_epoch(model, rDL, nll, optimizer, args)
         print(" \nEpoch {} loss: {}".format(m, sum(losses) / len(losses)))
         if args.save_model != "":

--- a/python/craftassist/voxel_models/subcomponent_classifier.py
+++ b/python/craftassist/voxel_models/subcomponent_classifier.py
@@ -22,10 +22,10 @@ from semseg_models import SemSegWrapper
 
 # TODO all "subcomponent" operations are replaced with InstSeg
 class SubcomponentClassifierWrapper:
-    def __init__(self, agent, model_path, perceive_freq=0):
+    def __init__(self, agent, model_path, vocab_path, perceive_freq=0):
         self.perceive_freq = perceive_freq
         if model_path is not None:
-            self.subcomponent_classifier = SubComponentClassifier(voxel_model_path=model_path)
+            self.subcomponent_classifier = SubComponentClassifier(voxel_model_path=model_path, vocab_path=vocab_path)
             self.subcomponent_classifier.start()
         else:
             self.subcomponent_classifier = None
@@ -82,14 +82,14 @@ class SubComponentClassifier(Process):
     A classifier class that calls a voxel model to output object tags.
     """
 
-    def __init__(self, voxel_model_path=None):
+    def __init__(self, voxel_model_path=None, vocab_path=None):
         super().__init__()
 
         if voxel_model_path is not None:
             logging.info(
                 "SubComponentClassifier using voxel_model_path={}".format(voxel_model_path)
             )
-            self.model = SemSegWrapper(voxel_model_path)
+            self.model = SemSegWrapper(voxel_model_path, vocab_path)
         else:
             raise Exception("specify a segmentation model")
 


### PR DESCRIPTION
# Intro
The material of a block in Minecraft is described with a pair of numbers: a block ID and a meta ID. The block ID describes the high-level category that the material belongs to, such as stone or wood. The meta ID describes a specific material within a block-ID category - for example, a block granite and one of andesite will both share the same block ID (i.e. high-level category) of stone, but will have different meta IDs. A list of different materials and their corresponding IDs can be found here:

https://minecraft-ids.grahamedgecombe.com/

Currently, CraftAssist’s semantic segmentation model only uses the block ID of each material, thus ignoring some of the finer-grained differences between blocks. This PR adds the meta IDs to model training and inference. Experiments show that the new model converges significantly faster than the original model, and has both higher validation accuracy and loss. This PR also includes a few quality-of-life improvements for training, such as progress bars monitoring to monitor training, periodically outputting validation loss, and adding model accuracy code (thanks @snyxan!).

# Experiments
Attached to this PR are the notebooks I used comparing model training on the original dataset with the new data. To summarize the results, the new model reaches 98.44% validation accuracy after a single epoch, with small accuracy improvements in later epochs (although both train and validation loss continue to go down). Training the model on the original dataset, by comparison, results in 78% validation accuracy after 1 epoch, with the model reaching 97.7% over the course of 50 epochs.

[notebooks.zip](https://github.com/facebookresearch/craftassist/files/4705448/notebooks.zip)


# Some implementation details
- Inside this PR is a script that produces a meta-id-added segmentation dataset from the current segmentation dataset and the house dataset. The latter is needed because this is where each block’s meta ID is stored (they are already removed in the original segmentation dataset). Something to note here is that some houses in the segmentation dataset could not be found in the house dataset - however, this did not make the new dataset significantly smaller. 
- To turn (block_id, meta_id) pairs into a single material identifier, the entire segmentation dataset is iterated through to produce a material vocabulary, which maps pairs of IDs to arbitrary material IDs. This vocabulary is needed at inference time to convert (block, meta) ID pairs into the same material IDs that the model has been trained on.

# Next Steps:
- Perhaps instead of mapping each unique (block, meta) pair into totally separate material ids, and therefore entirely separate embedding vectors, a hybrid-embedding approach could be used, where each material’s embedding consists of a shared embedding coming from the block ID concatenated with a unique embedding for each meta ID. This would allow the model to learn a general representation of “stone” for example, and then make this more specific for each sub-material. This is probably overkill though - I think more impactful improvements would be in the architecture of the model.
- Now that the model can differentiate between similar materials, data augmentations could be added to, for example, swap all the blocks  of stone type A in a house with stone type B.
- The segmentation model itself could be experimented with. The current architecture doesn’t do any up or downsampling and has no residual connections - I’d like to try both (i.e. build a small UNET).